### PR TITLE
Unlock the "Now Playing" page themes that were locked.

### DIFF
--- a/app/src/main/java/com/naman14/timber/utils/PreferencesUtility.java
+++ b/app/src/main/java/com/naman14/timber/utils/PreferencesUtility.java
@@ -246,7 +246,7 @@ public final class PreferencesUtility {
     }
 
     public boolean fullUnlocked() {
-        return mPreferences.getBoolean(FULL_UNLOCKED, false);
+        return mPreferences.getBoolean(FULL_UNLOCKED, true);
     }
 
     public void setFullUnlocked(final boolean b) {


### PR DESCRIPTION
Unlock the "Now Playing" page theme that were locked.

Also the reference to buying theme should be removed.

I'm not a java programmer but if I can I will look to be able to shutdown the 2 services of the player when they are not in use since they use a lot of memory 

![image](https://user-images.githubusercontent.com/5678673/59632539-6ae2c580-9118-11e9-9204-51ae8a6d35ab.png)



A last request you should enable the Issue section of the Github so the users would be able to contribute if they have issues with Timber.

Regards :octocat: 